### PR TITLE
ci: add publish-doc.yml and use main branch of shared-workflows

### DIFF
--- a/.github/workflows/build-docs.yml
+++ b/.github/workflows/build-docs.yml
@@ -1,9 +1,11 @@
 ---
-name: Publish released documentation
+name: Build docs
 on:
-  release:
+  pull_request:
     types:
-      - published
+      - opened
+      - reopened
+      - synchronize
 
 permissions:
   # required by actions/deploy-pages used in build-docs.yml
@@ -13,5 +15,3 @@ permissions:
 jobs:
   build-docs:
     uses: esp-idf-lib/shared-workflows/.github/workflows/build-docs.yml@main
-    with:
-      publish: true

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,7 +1,6 @@
 ---
 name: Build examples
 on:
-  push:
   pull_request:
     types:
       - opened
@@ -9,6 +8,4 @@ on:
       - synchronize
 jobs:
   build-examples:
-    uses: esp-idf-lib/shared-workflows/.github/workflows/build-examples.yml@v1.0.0
-  build-docs:
-    uses: esp-idf-lib/shared-workflows/.github/workflows/build-docs.yml@v1.1.0
+    uses: esp-idf-lib/shared-workflows/.github/workflows/build-examples.yml@main

--- a/docs/README.md
+++ b/docs/README.md
@@ -169,4 +169,7 @@ Welcome to Foo's documentation!
 
 ## Deploying the documentation
 
-TBW
+By default, the documentation is published on GitHub Pages when the component
+has been released. See [publish-gh-pages.yml](../.github/workflows/publish-doc.yml])
+and `build-docs.yml` at
+[esp-idf-lib/shared-workflows](https://github.com/esp-idf-lib/shared-workflows/tree/main/.github/workflows).


### PR DESCRIPTION
we might use tagged releases in the future, but for now, main is appropriate while developing workflows.